### PR TITLE
AutoPyTorch integration

### DIFF
--- a/managers/structureddata/AutoPyTorchManager.py
+++ b/managers/structureddata/AutoPyTorchManager.py
@@ -1,0 +1,12 @@
+from AutoMLManager import AutoMLManager
+
+
+class AutoPyTorchManager(AutoMLManager):
+    name = "AutoPyTorch"
+
+    def __init__(self, configuration, folder_location):
+        automl_service_host = 'AUTOPYTORCH_SERVICE_HOST'
+        automl_service_port = 'AUTOPYTORCH_SERVICE_PORT'
+        automl_default_port = '50059'
+        super(AutoPyTorchManager, self).__init__(configuration, folder_location, automl_service_host, automl_service_port,
+                                             automl_default_port)

--- a/managers/structureddata/AutoPyTorchManager.py
+++ b/managers/structureddata/AutoPyTorchManager.py
@@ -2,7 +2,7 @@ from AutoMLManager import AutoMLManager
 
 
 class AutoPyTorchManager(AutoMLManager):
-    name = "AutoPyTorch"
+    name = "autopytorch"
 
     def __init__(self, configuration, folder_location):
         automl_service_host = 'AUTOPYTORCH_SERVICE_HOST'

--- a/managers/structureddata/StructuredDataManager.py
+++ b/managers/structureddata/StructuredDataManager.py
@@ -5,6 +5,7 @@ from FLAMLManager import FLAMLManager
 from MljarManager import MljarManager
 from AutoMLSession import AutoMLSession
 from SklearnManager import SklearnManager
+from AutoPyTorchManager import AutoPyTorchManager
 
 
 class StructuredDataManager(object):
@@ -25,7 +26,7 @@ class StructuredDataManager(object):
         """
         if len(list(configuration.requiredAutoMLs)) == 0:
             print('No AutoMLs specified in the request. Running all available AutoMLs.')
-            required_automl_names = ('flaml', 'autokeras', 'autosklearn', 'autogluon', 'autocve')
+            required_automl_names = ('flaml', 'autokeras', 'autosklearn', 'autogluon', 'autocve', 'autopytorch')
         else:
             required_automl_names = [name for name in configuration.requiredAutoMLs]
 
@@ -41,6 +42,8 @@ class StructuredDataManager(object):
                 required_automls.append(AutoGluonManager(configuration, folder_location))
             elif automl_name == AutoCVEManager.name:
                 required_automls.append(AutoCVEManager(configuration, folder_location))
+            elif automl_name == AutoPyTorchManager.name:
+                required_automls.append(AutoPyTorchManager(configuration, folder_location))
 
         new_session = AutoMLSession(session_id, configuration.task)
         for automl in required_automls:


### PR DESCRIPTION
[#5](https://github.com/hochschule-darmstadt/MetaAutoML/issues/5) This adds the AutoPyTorch adapter to the managers. 
The adapter runs on port 50059 and is capable of doing regression and classification tasks.
The integration (and the adapter) is tested on the titanic and college dataset (for classification and regression respectively) and is in working order.